### PR TITLE
chore: prevent normalization of semver versioning

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,20 @@
 import os
-from setuptools import find_packages, setup
+import setuptools
+
+# Disable version normalization performed by setuptools.setup()
+try:
+    # Try the approach of using sic(), added in setuptools 46.1.0
+    from setuptools import sic
+except ImportError:
+    # Try the approach of replacing packaging.version.Version
+    sic = lambda v: v
+    try:
+        # setuptools >=39.0.0 uses packaging from setuptools.extern
+        from setuptools.extern import packaging
+    except ImportError:
+        # setuptools <39.0.0 uses packaging from pkg_resources.extern
+        from pkg_resources.extern import packaging
+    packaging.version.Version = packaging.version.LegacyVersion
 
 release_status = "Development Status :: 3 - Alpha"
 
@@ -8,9 +23,11 @@ readme_filename = os.path.join(package_root, "README.md")
 with open(readme_filename, encoding="utf-8") as readme_file:
     readme = readme_file.read()
 
-setup(
+version = "0.1.3"
+
+setuptools.setup(
     name="google-events",
-    version = "0.1.3",
+    version = sic(version),
     description="A collection of first party Google Cloud Platform event objects.",
     long_description=readme,
     long_description_content_type="text/markdown",
@@ -33,7 +50,7 @@ setup(
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
     ],
-    packages=find_packages("src"),
+    packages=setuptools.find_packages("src"),
     package_dir={"": "src"},
     python_requires=">=3.7",
     install_requires=['python-dateutil==2.8.1'],


### PR DESCRIPTION
When there is a patch version added to semver versioning, setuptools.setup(version) will normalize the versioning from `-patch` to `.patch` which is not correct SEMVER versioning. The added feature with setuptools.sic(version) will prevent this from happening.