### PR TITLE
docs: fix changelog header to consistent size

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,28 +7,28 @@
 
 * add support for python 3.10 ([#81](https://www.github.com/googleapis/google-cloudevents-python/issues/81)) ([b3396f5](https://www.github.com/googleapis/google-cloudevents-python/commit/b3396f5ce24cf582ad13325ef12081c93ecad6c9))
 
-### [0.1.4](https://www.github.com/googleapis/google-cloudevents-python/compare/v0.1.3...v0.1.4) (2021-05-28)
+## [0.1.4](https://www.github.com/googleapis/google-cloudevents-python/compare/v0.1.3...v0.1.4) (2021-05-28)
 
 
 ### Bug Fixes
 
 * **deps:** update dependency yargs to v17 ([#50](https://www.github.com/googleapis/google-cloudevents-python/issues/50)) ([203704e](https://www.github.com/googleapis/google-cloudevents-python/commit/203704e57c40d9191f9925a52e4a74afc10a7de9))
 
-### [0.1.3](https://www.github.com/googleapis/google-cloudevents-python/compare/v0.1.2...v0.1.3) (2021-02-26)
+## [0.1.3](https://www.github.com/googleapis/google-cloudevents-python/compare/v0.1.2...v0.1.3) (2021-02-26)
 
 
 ### Documentation
 
 * add pypi badge ([#38](https://www.github.com/googleapis/google-cloudevents-python/issues/38)) ([1832d9f](https://www.github.com/googleapis/google-cloudevents-python/commit/1832d9fcb64c2900df2f081d3a95e2b3cf833d0c))
 
-### [0.1.2](https://www.github.com/googleapis/google-cloudevents-python/compare/v0.1.1...v0.1.2) (2021-02-22)
+## [0.1.2](https://www.github.com/googleapis/google-cloudevents-python/compare/v0.1.1...v0.1.2) (2021-02-22)
 
 
 ### Bug Fixes
 
 * **packaging:** python module structure and dependencies ([#29](https://www.github.com/googleapis/google-cloudevents-python/issues/29)) ([0d3b38b](https://www.github.com/googleapis/google-cloudevents-python/commit/0d3b38b7c6df9aad8ba5f426d4f703c8a7bf663e))
 
-### [0.1.1](https://www.github.com/googleapis/google-cloudevents-python/compare/v0.1.0...v0.1.1) (2021-01-22)
+## [0.1.1](https://www.github.com/googleapis/google-cloudevents-python/compare/v0.1.0...v0.1.1) (2021-01-22)
 
 
 ### Bug Fixes


### PR DESCRIPTION
There was a minor issue with patch version releases labeled as an H3 header for changelog. Future changelog headers will always be H2 headers but existing entries must manually be fixed. Towards b/231248807.